### PR TITLE
Restructured the task by avoiding to use the variable as an argument …

### DIFF
--- a/tasks/lvm.yml
+++ b/tasks/lvm.yml
@@ -25,11 +25,14 @@
 
 - name: create LVM columes
   lvol:
-    vg: "{{ volume.lvm.vg }}"
-    lv: "{{ volume.lvm.lv }}"
-    size: "{{ volume.lvm.size }}"
-    pvs: "{{ volume.lvm.pvs }}"
+    active: "{{ volume.lvm.active|default(omit) }}"
+    force: "{{ volume.lvm.force|default(omit) }}"
+    lv: "{{ volume.lvm.lv|default(omit) }}"
     opts: "{{ volume.lvm.opts|default(omit) }}"
+    pvs: "{{ volume.lvm.pvs|default(omit) }}"
+    size: "{{ volume.lvm.size|default(omit) }}"
+    thinpool: "{{ volume.lvm.thinpool|default(omit) }}"
+    vg: "{{ volume.lvm.vg|default(omit) }}"
   loop_control:
     loop_var: volume
     index_var: volume_num

--- a/tasks/lvm.yml
+++ b/tasks/lvm.yml
@@ -24,7 +24,12 @@
   loop: "{{ lvm }}"
 
 - name: create LVM columes
-  lvol: "{{ volume.lvm }}"
+  lvol:
+    vg: "{{ volume.lvm.vg }}"
+    lv: "{{ volume.lvm.lv }}"
+    size: "{{ volume.lvm.size }}"
+    pvs: "{{ volume.lvm.pvs }}"
+    opts: "{{ volume.lvm.opts|default(omit) }}"
   loop_control:
     loop_var: volume
     index_var: volume_num


### PR DESCRIPTION
For avoiding to get the message below

>  TASK [debootstrap : create LVM columes] ***********************************************************************************************************************************************************************
>  [DEPRECATION WARNING]: Using variables for task params is unsafe, especially if the variables come from an external source like facts. This feature will be removed in version 2.6. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

have replaced the variable as the argument to the task "lvol" to the classical way.
Checked the module "lvol" and found that for creating logical volumes during debootstraping should be enough parameters "vg", "lv", "size", "pvs" and "opts"