### PR TITLE
Efi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ is strongly suggested you use ansible-vault here)
 
 ## Limitations
 * You can't have the same names for ZFS pools and crypto devices
-* currently no UEFI support (grub only)
 * no MD RAID / LVM
 * requires a /boot and BIOS boot partition for encrypted / ZFS
 
@@ -49,18 +48,19 @@ pools.
 # Configuration
 ## Global variables
 `release`: The release codename (**required**, example: *cosmic*)  
-`tgt_hostname`: Hostname of the target (**required**)
+`tgt_hostname`: Hostname of the target (**required**)  
 `root_password`: Hashed, Salted root password, you can use mkpasswd to create
 one (Example: `$1$sfQaZkVR$Vo/0pjmJaljzakEQFCr7Q/`, obviously **don't use this
 one ;) )**  
 `use_serial`: Serial device to use for console / grub  
 `use_tmpfs`: Bootstrap to tmpfs, it's quicker and may reduce wear on flash
 (**default**: *yes*)  
+`use_efi`: In case if a system supports UEFI, "grub-efi" will be installed on a target system otherwise "grub-pc" (**default**: *yes*)  
 `kernel_cmdline`: Anything you need/want to pass to the kernel (**default**:
 provided by distro)  
-`layout`: Dictionary of partitions / devices (**required**, see below)
+`layout`: Dictionary of partitions / devices (**required**, see below)  
 `md`: List of DM-RAID devices (see below)  
-`lvm`: List of LVM volumes (see below)    
+`lvm`: List of LVM volumes (see below)  
 `install_ppa`: PPAs to install (**Ubuntu Only**, see below)  
 `install_packages`: List of packages to install  
 `zfs_pool`: ZFS pool (see ZFS section)  

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,9 @@ install_packages: []
 # use tmpfs for debootstrap?
 use_tmpfs: yes
 
+# use efi?
+use_efi: yes
+
 locales:
 - en_US.UTF-8
 

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -47,6 +47,11 @@
     set_fact:
       _install: "{{ install_packages + required_packages['all'] + required_packages[release] }}"
 
+  - name: replace the package "grub-pc" to "grub-efi" in case of EFI
+    when: _stat_efi.stat.exists
+    set_fact:
+      _install: "{{ _install|map('regex_replace', 'grub-pc', 'grub-efi') | list }}"
+
   - debug:
       msg: "Going to install: {{ _install|join(', ') }}"
       verbosity: 2

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -48,7 +48,7 @@
       _install: "{{ install_packages + required_packages['all'] + required_packages[release] }}"
 
   - name: replace the package "grub-pc" to "grub-efi" in case of EFI
-    when: _stat_efi.stat.exists
+    when: use_efi and _stat_efi.stat.exists
     set_fact:
       _install: "{{ _install|map('regex_replace', 'grub-pc', 'grub-efi') | list }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,23 @@
 ---
 
+- name: Check EFI system
+  stat:
+    path: /sys/firmware/efi
+  register: _stat_efi
+
+- name: Check EFI mount point
+  when: _stat_efi.stat.exists
+  set_fact:
+    _efi_mountpoint: "{{ layout
+      | selectattr('partitions', 'defined')
+      | sum(attribute='partitions', start=[])
+      | selectattr('mount', 'defined')
+      | selectattr('mount', 'eq', '/boot/efi')
+      | map(attribute='mount')
+      | list
+      | first
+      | default(False) }}"
+
 - name: Cursory variable check
   include_tasks: sanity.yml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,13 @@
 ---
 
 - name: Check EFI system
+  when: use_efi
   stat:
     path: /sys/firmware/efi
   register: _stat_efi
 
 - name: Check EFI mount point
-  when: _stat_efi.stat.exists
+  when: use_efi and _stat_efi.stat.exists
   set_fact:
     _efi_mountpoint: "{{ layout
       | selectattr('partitions', 'defined')

--- a/tasks/mount.yml
+++ b/tasks/mount.yml
@@ -6,7 +6,7 @@
       {{ _mountpoints|default({})|combine({item.value['mount']: item.value|combine({'device': item.key })}) }}
   with_dict: "{{ _tgt_devices }}"
   when: >
-    not item.value['encrypt']|default(False) and item.value['fs']|default('undefined') in ['ext4', 'xfs'] and
+    not item.value['encrypt']|default(False) and item.value['fs']|default('undefined') in ['ext4', 'xfs', 'vfat'] and
     item.value['mount'] is defined
 
 - name: set ordered mount list

--- a/tasks/sanity.yml
+++ b/tasks/sanity.yml
@@ -13,3 +13,7 @@
 - fail:
     msg: root password doesn't look to be hashed, try using mkpasswd or something alike
   when: root_password is defined and root_password[0] != '$'
+
+- fail:
+    msg: EFI requires '/boot/efi' mount point
+  when: _efi_mountpoint is defined and not _efi_mountpoint

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,6 +9,7 @@ dependencies:
     - e2fsprogs
     - uuid-runtime
     - eatmydata
+    - dosfstools
   encryption:
     - cryptsetup
   lvm:


### PR DESCRIPTION
EFI support
1. Check if a system uses EFI by checking the directory /sys/firmware/efi
2. In the case of the system uses EFI checking that mount point  /boot/efi is defined and fail role if is not defined
3. Creating "vfat" file system on EFI partition and mount it to /boot/efi on a target
4. Replace "grub-pc" by "grub-efi" before installing required packages on the target