### PR TITLE
Added two packages "python3-minimal" and "sudo"

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -40,6 +40,8 @@ required_packages:
     - openssh-server
     - locales
     - python-minimal # assuming you want to run ansible, too
+    - python3-minimal
+    - sudo
   bionic:
     - linux-image-generic
   cosmic:


### PR DESCRIPTION
Added two packages into the list of required_packages.
* python3-minimal - for running ansible which runs with python3
* sudo - in Debian 9 role is failed on the task:
    `tasks/main.yml:190:    - name: allow sudo for debootstrap user`
  because of the directory `/etc/sudoers.d` is missing. This directory is creating by `sudo` package