### PR TITLE
Debootstrap user improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ provided by distro)
 remove any disklabels present as well as issue a TRIM/UNMAP for the device.
 Useful when you want to overwrite a target. **Please use extreme caution**  
 
+## Debootstrap user options
+`dbstrp_user`:  
+  `name`: A name of debootstrap user (**default**: *debootstrap*)  
+  `uid`: UID of debootstrap user (**default**: *65533*)  
+  `group`: A group name of debootstrap user (**default**: *name of debootstrap user*)  
+  `gid`: GID of debootstrap user (**default**: *uid of debootstrap user*)  
+  `password`: A hashed password of debootstrap user (**default**: *\**)  
+  `non_unique`: Ability to create non unique user (**default**: *yes*)  
+
 ## Partition Layout `layout`
 Layout is a list of dictionaries, every dictionary representing a target
 device. The dictionary contains the device names, as well as another list of

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,22 +108,17 @@
         state: directory
         path: "{{ dbstrp_mountpoint }}"
 
-    - name: setup bootstrap user
-      user:
-        name: debootstrap
-        create_home: no
-        home: "{{ dbstrp_mountpoint }}"
-        shell: "/bin/bash"
-        groups:
-          - sudo
-        uid: 65533
+    - name: create debootstrap user
+      include_tasks: user.yml
+      vars:
+        _tgt_user: no
 
     - name: chroot user via ssh
       blockinfile:
         path: "/etc/ssh/sshd_config"
         state: present
         block: >
-          Match user debootstrap
+          Match user {{ dbstrp_user['name'] }}
               ChrootDirectory {{ dbstrp_mountpoint }}
               AuthorizedKeysFile /tmp/authorized_keys
       register: _ssh_config
@@ -170,30 +165,31 @@
     - name: configure system
       include_tasks: configure.yml
 
-    - name: create bootstrap user on target
-      command: >
-        chroot {{ dbstrp_mountpoint }} useradd -m -U -u 65533 -s /bin/bash {{ dbstrp_username|default('debootstrap') }}
+    - name: create debootstrap user on target
+      include_tasks: user.yml
+      vars:
+        _tgt_user: yes
 
     - name: create ssh directory for bootstrap user
       file:
         state: directory
-        path: "{{ dbstrp_mountpoint }}/home/debootstrap/.ssh"
-        owner: "{{ dbstrp_username|default('debootstrap') }}"
+        path: "{{ dbstrp_mountpoint }}/home/{{ dbstrp_user['name'] }}/.ssh"
+        owner: "{{ dbstrp_user['name'] }}"
 
     - name: setup keys for bootstrap user
       authorized_key:
         key: "{{ item }}"
         path: "/tmp/authorized_keys"
-        user: "{{ dbstrp_username|default('debootstrap') }}"
+        user: "{{ dbstrp_user['name'] }}"
       with_items: "{{ dbstrp_ssh_keys }}"
 
     - name: allow sudo for debootstrap user
       copy:
-        dest: "{{ dbstrp_mountpoint }}/etc/sudoers.d/debootstrap"
+        dest: "{{ dbstrp_mountpoint }}/etc/sudoers.d/{{ dbstrp_user['name'] }}"
         owner: root
         group: root
         mode: 0440
-        content: "{{ dbstrp_username|default('debootstrap') }} ALL=(ALL) NOPASSWD:ALL"
+        content: "{{ dbstrp_user['name'] }} ALL=(ALL) NOPASSWD:ALL"
 
     - name: mark as bootstrapped
       copy:

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -1,0 +1,63 @@
+---
+- block:
+    - name: setup user properties
+      set_fact:
+        dbstrp_user: "{{ _dbstrp_user|combine(dbstrp_user|default({})) }}"
+
+    - fail:
+        msg: an user who runs 'debootstrap' role and an user created on target system should be different
+      when: (ansible_user == dbstrp_user['name']) or
+        (ansible_ssh_user == dbstrp_user['name'])
+
+    - name: setup group name
+      when: not dbstrp_user['group']
+      set_fact:
+        dbstrp_user: "{{ dbstrp_user|combine({'group': dbstrp_user['name']}) }}"
+
+    - name: setup group id
+      when: not dbstrp_user['gid']
+      set_fact:
+        dbstrp_user: "{{ dbstrp_user|combine({'gid': dbstrp_user['uid']}) }}"
+
+    - name: getent group
+      getent:
+        database: group
+        key: "{{ dbstrp_user['group'] }}"
+        fail_key: no
+
+    - name: create group if absent
+      when: not getent_group[dbstrp_user['group']]
+      command: groupadd -o -g "{{ dbstrp_user['gid'] }}" "{{ dbstrp_user['group'] }}"
+
+    - name: getent passwd
+      getent:
+        database: passwd
+        key: "{{ dbstrp_user['name'] }}"
+        fail_key: no
+
+    - name: setup bootstrap user
+      when: not getent_passwd[dbstrp_user['name']]
+      user:
+        name: "{{ dbstrp_user['name'] }}"
+        create_home: no
+        home: "{{ dbstrp_mountpoint }}"
+        shell: "/bin/bash"
+        groups:
+          - sudo
+        uid: "{{ dbstrp_user['uid'] }}"
+        group: "{{ dbstrp_user['group'] }}"
+        non_unique: "{{ dbstrp_user['non_unique'] }}"
+  when: not _tgt_user
+
+# create user on target
+- block:
+    - name: create bootstrap user group on target
+      command: >
+        chroot {{ dbstrp_mountpoint }} groupadd -o -g {{ dbstrp_user['gid'] }} {{ dbstrp_user['group'] }}
+
+    - name: create bootstrap user on target
+      command: >
+        chroot {{ dbstrp_mountpoint }} useradd -m -u {{ dbstrp_user['uid'] }} -s /bin/bash
+          -g {{ dbstrp_user['group'] }} -p {{ dbstrp_user['password'] }}
+          {{ dbstrp_user['name'] }}
+  when: _tgt_user

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -68,3 +68,11 @@ dbstrp_label_max:
   ext4: 16
   vfat: 11
   xfs: 12
+
+_dbstrp_user:
+  name: debootstrap
+  uid: 65533
+  group: ~
+  gid: ~
+  password: '*'
+  non_unique: yes


### PR DESCRIPTION
Added some improvements for the debootstrap user. Now is possible to use other names for user and groups. The same for uid and gid. Also possible to use a password.
Should admit that the solution not so elegant however it works.