### PR TITLE
Added mounting '/run/udev' to debootstrapped system because of grub-u…

### DIFF
--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -127,9 +127,6 @@
   environment: "{{ _apt_env }}"
 
 - block:
-  - debug:
-      msg: "{{ pseudo_fs|reverse|list }}"
-
   - name: umount pseudo filesystems
     command: umount {{ _bootstrap_target }}/{{ item }}
     with_items: "{{ pseudo_fs|reverse|list }}"

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -31,11 +31,7 @@
   - name: bind mount pseudo filesystems
     shell: "mkdir {{ _bootstrap_target }}/{{ item }}; mount --bind /{{ item }} {{ _bootstrap_target }}/{{ item }} warn=no"
     register: _pseudomount
-    with_items:
-    - proc
-    - sys
-    - dev
-    - dev/pts
+    with_items: "{{ pseudo_fs }}"
 
   - name: Link mtab
     file:
@@ -131,13 +127,12 @@
   environment: "{{ _apt_env }}"
 
 - block:
+  - debug:
+      msg: "{{ pseudo_fs|reverse|list }}"
+
   - name: umount pseudo filesystems
     command: umount {{ _bootstrap_target }}/{{ item }}
-    with_items:
-    - dev/pts
-    - proc
-    - sys
-    - dev
+    with_items: "{{ pseudo_fs|reverse|list }}"
 
   - name: copy data from temp
     shell: cp -a {{ _bootstrap_target }}/* {{ _tgt_root }}/
@@ -145,11 +140,7 @@
   - name: bind mount pseudo filesystems
     shell: mkdir {{ _tgt_root }}/{{ item }}; mount --bind /{{ item }} {{ _tgt_root }}/{{ item }}
     register: _pseudomount
-    with_items:
-    - proc
-    - sys
-    - dev
-    - dev/pts
+    with_items: "{{ pseudo_fs }}"
 
   - name: umount tmpfs
     command: "umount {{ _bootstrap_target }}"

--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -10,11 +10,7 @@
 
 - name: umount pseudo filesystems
   command: umount {{ _tgt_root }}/{{ item }}
-  with_items:
-  - dev/pts
-  - proc
-  - sys
-  - dev
+  with_items: "{{ pseudo_fs|reverse }}"
   when: _pseudomount is defined and _pseudomount.changed
 
 - name: umount target

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -83,3 +83,9 @@ _dbstrp_user:
   password: '*'
   non_unique: yes
 
+pseudo_fs:
+  - proc
+  - sys
+  - dev
+  - dev/pts
+  - run/udev


### PR DESCRIPTION
1. Added mounting '/run/udev' to debootstrapped system because of grub-update needed it in case of using LVM on Debian Buster

The role hangs on task `TASK [debootstrap : set up grub]`
At this moment in the target system, I could find hung `vgs` process, see below
```
root      1660     1  0 17:03 ?        00:00:00 sshd: user [priv]
1000      1666  1660  0 17:03 ?        00:00:00  \_ sshd: user@pts/0
1000     25094  1666  0 17:11 pts/0    00:00:00      \_ /bin/sh -c sudo -H -S -n -u root /bin/sh -c 'echo BECOME-SUCCESS-lugovysvyncfxwwosdqzljphbvhjjtmf; /usr/bin/python3 /home/user/.ansible/tmp/ansible-tmp-1561914695.0743527-209614821695683/command.py' && sleep 0
root     25095 25094  0 17:11 pts/0    00:00:00          \_ sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-lugovysvyncfxwwosdqzljphbvhjjtmf; /usr/bin/python3 /home/user/.ansible/tmp/ansible-tmp-1561914695.0743527-209614821695683/command.py
root     25096 25095  0 17:11 pts/0    00:00:00              \_ /bin/sh -c echo BECOME-SUCCESS-lugovysvyncfxwwosdqzljphbvhjjtmf; /usr/bin/python3 /home/user/.ansible/tmp/ansible-tmp-1561914695.0743527-209614821695683/command.py
root     25097 25096  0 17:11 pts/0    00:00:00                  \_ /usr/bin/python3 /home/user/.ansible/tmp/ansible-tmp-1561914695.0743527-209614821695683/command.py
root     25098 25097  0 17:11 pts/0    00:00:00                      \_ /usr/bin/python3 /tmp/ansible_8k76u0r3/ansible_module_command.py
root     25099 25098  0 17:11 pts/0    00:00:00                          \_ /bin/sh /usr/sbin/grub-mkconfig -o /boot/grub/grub.cfg
root     25106 25099  0 17:11 pts/0    00:00:00                              \_ /usr/sbin/grub-probe --device /dev/mapper/vg0-lv_root --target=fs_uuid
root     25216 25106  0 17:14 pts/0    00:00:00                                  \_ vgs --options vg_uuid,pv_name --noheadings --separator :
```
ran `strace` and found that `vgs` tried to open some files in `/run/udev` but couldn't open
```
% grep '/run/udev' vgs.strace.25439
access("/run/udev/control", F_OK)       = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/run/udev/data/b7:0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/run/udev/data/b7:0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/run/udev/data/b7:0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
openat(AT_FDCWD, "/run/udev/data/b7:0", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
...
```
so mounting the directory `/run/udev` from installation media fixed the issue

2. Also created a variable `pseudo_fs` with all pseudo filesystems and replaced lists with these filesystems in all tasks to the one variable