### PR TITLE
#20 round down luks partition to luks sector size boundary

### DIFF
--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+
+def filter_2sectors(size, metric_prefix=None, sector_size_b=512):
+    '''
+    Convertion disk size with metric prefixes to size in sectors
+    "size" - disk size with or without metric prefix
+    "metric_prefix" - metric prefix, default "None"
+    "sector_size_b" - logical sector size, default "512B"
+    '''
+
+    if metric_prefix:
+        _size = size.upper() + metric_prefix
+    else:
+        _size = size.upper()
+
+    if 'B' in _size:
+        return int(_size.split('B')[0]) / sector_size_b
+    elif 'K' in _size:
+        return int(_size.split('K')[0]) * 1024 / sector_size_b
+    elif 'M' in _size:
+        return int(_size.split('M')[0]) * 1024**2 / sector_size_b
+    elif 'G' in _size:
+        return int(_size.split('G')[0]) * 1024**3 / sector_size_b
+    elif 'P' in _size:
+        return int(_size.split('G')[0]) * 1024**4 / sector_size_b
+    else:
+        return int(_size)
+
+
+class FilterModule(object):
+    '''
+    Ansible filters
+    '''
+    def filters(self):
+        return {
+            # jinja2 overrides
+            'f_2sectors': filter_2sectors
+        }
+
+if __name__ == '__main__':
+    from pprint import pprint
+
+    _list = ['128M', '2M', '256M', '3G']
+    [print(filter_2sectors(item)) for item in _list]

--- a/tasks/encryption.yml
+++ b/tasks/encryption.yml
@@ -27,35 +27,23 @@
     with_dict: "{{ _tgt_devices }}"
     when: item.value['encrypt']|default(False)
 
-  - name: create encrypted devices (LUKS2)
+  - name: create encrypted devices
     command: >
       cryptsetup -q --cipher {{ item.value['cipher']|default('aes-xts-plain64') }}
-      --type {{ item.value['luks-type']|default('luks2') }} --sector-size {{ item.value['luks-sector-size']|default(4096) }}
-      --key-size {{ item.value['key-size']|default('256') }}  --hash {{ item.value['hash']|default('sha512') }}
+      --type {{ item.value['luks-type']|default(luks_type) }}
+      {{ luks_sector_size if luks_version|int == 2 else '' }}
+      --key-size {{ item.value['key-size']|default('256') }} --hash {{ item.value['hash']|default('sha512') }}
       --iter-time {{ item.value['iter-time']|default('5000') }} luksFormat {{ item.key }}
     args:
       stdin: "{{ item.value['passphrase'] }}"
     no_log: true
+    vars:
+      luks_version: "{{ 2 if cryptsetup_version[0]|int >= 2 else 1 }}"
+      luks_type: "{{ 'luks2' if luks_version|int == 2 else 'luks' }}"
+      luks_sector_size: "--sector-size {{ item.value['luks-sector-size']|default(4096) }}"
     loop_control:
       label: "{{ item.key }}"
     with_dict: "{{ _encrypt_targets|default({}) }}"
-    when:
-    - cryptsetup_version[0]|int >= 2
-
-  - name: create encrypted devices (LUKS1)
-    command: >
-      cryptsetup -q --cipher {{ item.value['cipher']|default('aes-xts-plain64') }}
-      --type {{ item.value['luks-type']|default('luks') }}
-      --key-size {{ item.value['key-size']|default('256') }}  --hash {{ item.value['hash']|default('sha512') }}
-      --iter-time {{ item.value['iter-time']|default('5000') }} luksFormat {{ item.key }}
-    args:
-      stdin: "{{ item.value['passphrase'] }}"
-    no_log: true
-    loop_control:
-      label: "{{ item.key }}"
-    with_dict: "{{ _encrypt_targets|default({}) }}"
-    when:
-    - cryptsetup_version[0]|int < 2
 
   - name: fetch luks UUID for device
     command: "cryptsetup luksUUID {{ item.key }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,48 @@
 ---
 
+- name: Get disks sizes, logical and physical sectors sizes
+  command: blockdev --"{{ cmd_param }}" "{{ device }}"
+  check_mode: no
+  vars:
+    device: "{{ item.0 }}"
+    cmd_param: "{{ item.1 }}"
+  loop: "{{ (layout | selectattr('device', 'defined') | map(attribute='device') | list) | product(['getss', 'getpbsz', 'getsize64']) | list }}"
+  loop_control:
+    label: "{{ device }} / {{ cmd_param }}"
+  register: _cmd_blockdev_result
+
+- name: Calculate some disks attributes
+  set_fact:
+    device_attrs: "{{
+      device_attrs|default([])
+        | union([{'device': device,
+                  'devsz_b': _devsz_b,
+                  'lbsz_b': _lbsz_b,
+                  'pbsz_b':  _pbsz_b,
+                  'last_usable_sector_s': _last_usable_sector_s,
+                  'offset_s': _offset_s}
+                ])
+    }}"
+  vars:
+    # Get all needed disk's attributes in a one disk
+    _device_attrs: "{{ _cmd_blockdev_result.results | selectattr('item') | selectattr('item.0', 'eq', device) | list }}"
+    _lbsz_b: "{{ _device_attrs  | selectattr('item.1', 'eq', 'getss')     | map(attribute='stdout') | first }}"
+    _pbsz_b: "{{ _device_attrs  | selectattr('item.1', 'eq', 'getpbsz')   | map(attribute='stdout') | first }}"
+    _devsz_b: "{{ _device_attrs | selectattr('item.1', 'eq', 'getsize64') | map(attribute='stdout') | first }}"
+    _efi_label_size_s: 34
+    _last_usable_sector_s: "{{ _devsz_b|int / _lbsz_b|int - _efi_label_size_s }}"
+    _offset_s: "{{ 2048 if _pbsz_b|int == 512 else (4096 if _pbsz_b|int == 4096 else 0) }}"
+  # Loop over disks name
+  loop: "{{ _cmd_blockdev_result.results | selectattr('item') | map(attribute='item.0') | list | unique }}"
+  loop_control:
+    loop_var: device
+
+- name: Combine disks layouts with disks attributes
+  when: item.0.device == item.1.device
+  set_fact:
+    layout_w_attrs: "{{ layout_w_attrs|default([]) | union([item.0 | combine(item.1)]) }}"
+  loop: "{{ layout | zip(device_attrs) | list }}"
+
 - name: Check EFI system
   when: use_efi
   stat:

--- a/tasks/partitions.yml
+++ b/tasks/partitions.yml
@@ -43,10 +43,11 @@
   command: >
     sgdisk
     {%- for partition in item.partitions -%}
-    {%- if "nvme" in item.device -%}
-    {%- set __devname=item.device + 'p' + partition.num|string -%}
-    {%- else %}
-    {%- set __devname=item.device + partition.num|string -%}
+    {%- set __devname=item.device + ('p' if 'nvme' in item.device else '') + partition.num|string -%}
+    {%- if 'size' not in partition -%}
+      {#- The size in sectors -#}
+      {%- set size = (item.last_usable_sector_s|int - item.offset_s|int - (item.partitions|selectattr('size','defined')|map(attribute='size')|map('f_2sectors')|list|sum)) * item.lbsz_b|int // 4096 * 4096 / item.lbsz_b|int -%}
+      {%- set partition = partition|combine({'size': size|string})-%}
     {%- endif %}
     -n {{ partition.num }}:0:{% if partition.size is defined and partition.size[0] != '+'%}+{%endif%}{{ partition.size|default(0) }}
     -t {{ partition.num }}:{{ partition.type|default('8200') }}
@@ -55,7 +56,7 @@
     -c {{ partition.num }}:{{ partition.partlabel|default(partition.label) }}
     {%- endif -%}
     {% endfor %} {{ item.device }}
-  with_items: "{{ layout }}"
+  with_items: "{{ layout_w_attrs }}"
 
 - name: find devices for partuuid
   command: "blkid -l -o device -t PARTUUID='{{ item.value }}'"
@@ -68,7 +69,7 @@
   with_items: "{{ _blkid.results }}"
 
 - debug:
-    var: layout
+    var: layout_w_attrs
     verbosity: 2
 
 - debug:


### PR DESCRIPTION
It is a possible improvement for the issue #20
Not sure if it is fully match with the reported issue but I had the issue with LUKS formatting on the partitions which are defined without size (usually it is the last partition on the disk and should use all remaining disk space). `sgdisk` creates them without proper 4k alignment. So this PR contains the code for calculation the size of the last partition with 4k alignment.
Plus some small not critical improvements.