### PR TITLE
Added option to create symlinks; added option to have a predictable p…

### DIFF
--- a/tasks/md.yml
+++ b/tasks/md.yml
@@ -18,9 +18,28 @@
 - name: create MD devices
   command: >
     mdadm --create /dev/md{{ 127 - device_num }} --level {{ device.level }} --raid-devices {{ device.members|count }}
+    --symlinks yes --homehost={{ inventory_hostname_short | default('any') }}
     {% if device.level != 0 %}--bitmap={{ device.bitmap|default("internal") }} {% endif %}
     --name {{ device.name }} --metadata 1.2
     {% if 'chunk_size' in device %}--chunk {{ device.chunk_size }}{% endif %} {{ device.members|join(" ") }}
+  loop_control:
+    index_var: device_num
+    loop_var: device
+  loop: "{{ md }}"
+
+- name: create "/dev/md" directory
+  file:
+    path: /dev/md
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+
+- name: debug md
+  file:
+    src: "../md{{ 127 - device_num }}"
+    dest: "/dev/md/{{ device.name }}"
+    state: link
   loop_control:
     index_var: device_num
     loop_var: device


### PR DESCRIPTION
Added option to create symlinks; added option to have a predictable prefix before the name of MD device; added creating of the directory "/dev/md" and MD names symlinks to MD devices inside.

This change has appeared when I needed to use MD device in LVM like below

```
- lvm: {'lv': 'lv_volumes', 'vg': 'vg1', 'size': '100%PVS', 'pvs': '/dev/md/mdvolumes'}
```

So this PR creates `/dev/md` directory and MD name symlinks inside to MD devices like `md127`, `md126` etc.
Also this PR adds some options:
* `--symlinks yes` - it should create all symlinks automatically but doesn't work for me (Debian 11 Live)
* `--homehost=` - it creates a predictable hostname prefix before MD name

Example:
```
root@vertica1:~# mdadm --detail /dev/md127 | grep Name
              Name : vertica1:mdvolumes  (local to host vertica1)
```
