### PR TITLE
Replaced multiple calls of the command "blockdev" by one call of the …

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,47 +1,34 @@
 ---
 
 - name: Get disks sizes, logical and physical sectors sizes
-  command: blockdev --"{{ cmd_param }}" "{{ device }}"
+  command: "lsblk -d -b -O --json {{ layout | selectattr('device', 'defined') | map(attribute='device') | list | join(' ') }}"
   check_mode: no
-  vars:
-    device: "{{ item.0 }}"
-    cmd_param: "{{ item.1 }}"
-  loop: "{{ (layout | selectattr('device', 'defined') | map(attribute='device') | list) | product(['getss', 'getpbsz', 'getsize64']) | list }}"
-  loop_control:
-    label: "{{ device }} / {{ cmd_param }}"
-  register: _cmd_blockdev_result
+  register: _cmd_lsblk_result
 
 - name: Calculate some disks attributes
+  when: _cmd_lsblk_result.rc is defined and _cmd_lsblk_result.rc | int == 0
   set_fact:
     device_attrs: "{{
       device_attrs|default([])
-        | union([{'device': device,
-                  'devsz_b': _devsz_b,
-                  'lbsz_b': _lbsz_b,
-                  'pbsz_b':  _pbsz_b,
-                  'last_usable_sector_s': _last_usable_sector_s,
-                  'offset_s': _offset_s}
+        | union([{'device': '/dev/' + item['name'],
+                  'devsz_b': item['size'],
+                  'lbsz_b': item['log-sec'],
+                  'pbsz_b':  item['phy-sec'],
+                  'last_usable_sector_s': item['size']|int / item['log-sec']|int - _efi_label_size_s,
+                  'offset_s': 2048 if item['phy-sec']|int == 512 else (4096 if item['phy-sec']|int == 4096 else 0)}
                 ])
     }}"
   vars:
-    # Get all needed disk's attributes in a one disk
-    _device_attrs: "{{ _cmd_blockdev_result.results | selectattr('item') | selectattr('item.0', 'eq', device) | list }}"
-    _lbsz_b: "{{ _device_attrs  | selectattr('item.1', 'eq', 'getss')     | map(attribute='stdout') | first }}"
-    _pbsz_b: "{{ _device_attrs  | selectattr('item.1', 'eq', 'getpbsz')   | map(attribute='stdout') | first }}"
-    _devsz_b: "{{ _device_attrs | selectattr('item.1', 'eq', 'getsize64') | map(attribute='stdout') | first }}"
     _efi_label_size_s: 34
-    _last_usable_sector_s: "{{ _devsz_b|int / _lbsz_b|int - _efi_label_size_s }}"
-    _offset_s: "{{ 2048 if _pbsz_b|int == 512 else (4096 if _pbsz_b|int == 4096 else 0) }}"
-  # Loop over disks name
-  loop: "{{ _cmd_blockdev_result.results | selectattr('item') | map(attribute='item.0') | list | unique }}"
+  loop: "{{ _cmd_lsblk_result.stdout | from_json | dict2items | selectattr('value','defined') | map(attribute='value') | flatten(levels=1) }}"
   loop_control:
-    loop_var: device
+    label: "{{ item.name }}"
 
 - name: Combine disks layouts with disks attributes
   when: item.0.device == item.1.device
   set_fact:
     layout_w_attrs: "{{ layout_w_attrs|default([]) | union([item.0 | combine(item.1)]) }}"
-  loop: "{{ layout | zip(device_attrs) | list }}"
+  loop: "{{ layout|sort(attribute='device') | zip(device_attrs|sort(attribute='device')) | list }}"
 
 - name: Check EFI system
   when: use_efi


### PR DESCRIPTION
Replaced multiple calls of the command `blockdev` by one call of the command `lsblk`

The command `blockdev` executes 3 times for every disk to get disk's attribute: `getss`, `getpbsz` and `getsize64`
In the case of a big amount of disks (`24`) it has to be executed `72` times what is not very good.

So, decided to replace the command `blockdev` with at least 3 execution in the case of one disk to the command `lsblk` with one execution with any number of disks.
