### PR TITLE
the package python-minimal does not exist on bullseye.

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -71,7 +71,7 @@ required_packages:
     - python-minimal
     - linux-image-amd64
   bullseye:
-    - python-minimal
+    - python3-minimal
     - linux-image-amd64
 
 _apt_env:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -71,7 +71,6 @@ required_packages:
     - python-minimal
     - linux-image-amd64
   bullseye:
-    - python3-minimal
     - linux-image-amd64
 
 _apt_env:


### PR DESCRIPTION
use python3-minimal instead.