### PR TITLE
Added ability to use compaction for multiple devices with similar par…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,20 @@
 ---
 
+- name: Expand "layout" variable
+  set_fact:
+    layout_n: "{{ layout_n|default([]) + _layout_n|list }}"
+  loop: "{{ layout | selectattr('device', 'defined') | list }}"
+  vars:
+    _layout_n: |-
+      {%- for _item in ([item.device] if item.device is string else item.device) -%}
+        {{ item | combine({'device': _item}) }},
+      {%- endfor -%}
+
+- name: Update "layout" variable
+  when: layout_n | selectattr('device', 'defined') | list | length > 0
+  set_fact:
+    layout: "{{ layout_n }}"
+
 - name: Get disks sizes, logical and physical sectors sizes
   command: blockdev --"{{ cmd_param }}" "{{ device }}"
   check_mode: no


### PR DESCRIPTION
Have a server with 12 disks in software raid. Was needed to use 12 stanzas - 1 for every disk for describing disk partitions:

```yaml
  - device: '/dev/sda'
    partitions:
      - {'num': '1', 'size':  '2M', 'type': 'ef02'}  # /dev/sda1
      - {'num': '2', 'size': '64M', 'type': '8300'}  # /dev/sda2
      - {'num': '3',                'type': '8300'}  # /dev/sda3
    skip_grub: False
  ---%<---- cut ----->%---
  - device: '/dev/sdl'
    partitions:
      - {'num': '1', 'size':  '2M', 'type': 'ef02'}  # /dev/sdl1
      - {'num': '2', 'size': '64M', 'type': '8300'}  # /dev/sdl2
      - {'num': '3',                'type': '8300'}  # /dev/sdl3
    skip_grub: False
```

After the change is needed only one stanza:

```yaml
  - device: ['/dev/sda','/dev/sdb','/dev/sdc','/dev/sdd','/dev/sde','/dev/sdf','/dev/sdg','/dev/sdh','/dev/sdi','/dev/sdj','/dev/sdk','/dev/sdl']
    partitions:
      - {'num': '1', 'size':  '2M', 'type': 'ef02'}  # /dev/sd[a-l]1
      - {'num': '2', 'size': '64M', 'type': '8300'}  # /dev/sd[a-l]2
      - {'num': '3',                'type': '8300'}  # /dev/sd[a-l]3
    skip_grub: False
```